### PR TITLE
Parse some more commands

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -250,6 +250,8 @@ func main() {
 				ctrl.SendToRadioMsgChannel([]byte("MSI," + string(buffer[4:])))
 			case "DTM":
 				log.Infoln("DTM:", string(buffer[4:]))
+				timeInfo := NewDateTimeInfo(string(buffer[4:n]))
+				log.Infof("DTM: DST?: %t, Time: %s, RTC OK? %t\n", timeInfo.DaylightSavings, timeInfo.Time, timeInfo.RTCOK)
 				ctrl.SendToRadioMsgChannel([]byte("DTM," + string(buffer[4:])))
 			case "LCR":
 				log.Infoln("LCR:", string(buffer[4:]))

--- a/server/main.go
+++ b/server/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/xml"
 	"flag"
+	"fmt"
 	"net"
 	"os/signal"
 
@@ -187,7 +188,7 @@ func main() {
 
 			if bytes.Equal(buffer[4:9], []byte(`<XML>`)) {
 				xmlMessageType = string(buffer[0:3])
-				xmlMessage = append(xmlMessage, buffer[0:n]...)
+				copy(xmlMessage, buffer[0:n])
 				if IsValidXMLMessage(xmlMessageType, xmlMessage) == false {
 					isXML = true
 					continue
@@ -203,7 +204,8 @@ func main() {
 				if IsValidXMLMessage(xmlMessageType, xmlMessage) == false {
 					continue
 				}
-				buffer = xmlMessage
+				// Double comma to match the /r that is normally here
+				buffer = []byte(fmt.Sprintf(`%s,<XML>,,%s`, xmlMessageType, string(xmlMessage)))
 				isXML = false
 				xmlMessageType = ""
 				xmlMessage = make([]byte, 0)

--- a/server/main.go
+++ b/server/main.go
@@ -258,6 +258,11 @@ func main() {
 				log.Infoln("URC:", string(buffer[4:]))
 				ctrl.SendToRadioMsgChannel([]byte("URC," + string(buffer[4:])))
 			case "STS":
+				log.Infoln("STS", string(buffer[4:]))
+				stsInfo := NewScannerStatus(string(buffer[4:]))
+				log.Infof("STS: Line 1: %s, Line 2: %s, Line 3: %s, Line 4: %s, SQL: %t, Signal Level: %d\n",
+					stsInfo.Line1, stsInfo.Line2, stsInfo.Line3, stsInfo.Line4, stsInfo.Squelch, stsInfo.SignalLevel)
+				ctrl.SendToRadioMsgChannel([]byte("STS," + string(buffer[4:])))
 			case "GLG":
 			case "GLT":
 				switch getXmlGLTFormatType(buffer[11:]) {

--- a/server/main.go
+++ b/server/main.go
@@ -16,6 +16,7 @@ import (
 )
 
 type SDSKeyType string
+type SDSKeyModeType string
 type GltXmlType int
 
 const (
@@ -55,6 +56,11 @@ const (
 	KEY_ZIP       SDSKeyType = "Z"
 	KEY_SERV      SDSKeyType = "T"
 	KEY_RANGE     SDSKeyType = "R"
+
+	KEY_MODE_PRESS   SDSKeyModeType = "P" // Press (One Push)
+	KEY_MODE_LONG    SDSKeyModeType = "L" // Long Press (Press and Hold a few seconds)
+	KEY_MODE_HOLD    SDSKeyModeType = "H" // Hold (Press and Hold until Release receive)
+	KEY_MODE_RELEASE SDSKeyModeType = "R" // Release (Cancel Hold state
 
 	GltXmlUnknown GltXmlType = -1
 	GltXmlFL      GltXmlType = iota

--- a/server/main.go
+++ b/server/main.go
@@ -260,6 +260,8 @@ func main() {
 				ctrl.SendToRadioMsgChannel([]byte("LCR," + string(buffer[4:])))
 			case "URC":
 				log.Infoln("URC:", string(buffer[4:]))
+				recStatus := NewUserRecordStatus(string(buffer[4:n]))
+				log.Infof("URC: Recording? %t, ErrorCode: %d, ErrorMessage: %s\n", recStatus.Recording, recStatus.ErrorCode, recStatus.ErrorMessage)
 				ctrl.SendToRadioMsgChannel([]byte("URC," + string(buffer[4:])))
 			case "STS":
 				log.Infoln("STS", string(buffer[4:]))

--- a/server/main.go
+++ b/server/main.go
@@ -205,7 +205,11 @@ func main() {
 					continue
 				}
 				// Double comma to match the /r that is normally here
-				buffer = []byte(fmt.Sprintf(`%s,<XML>,,%s`, xmlMessageType, string(xmlMessage)))
+				comma := ","
+				if xmlMessageType == "GSI" || xmlMessageType == "PSI" {
+					comma = ",,"
+				}
+				buffer = []byte(fmt.Sprintf(`%s,<XML>%s%s`, xmlMessageType, comma, string(xmlMessage)))
 				isXML = false
 				xmlMessageType = ""
 				xmlMessage = make([]byte, 0)

--- a/server/main.go
+++ b/server/main.go
@@ -255,6 +255,8 @@ func main() {
 				ctrl.SendToRadioMsgChannel([]byte("DTM," + string(buffer[4:])))
 			case "LCR":
 				log.Infoln("LCR:", string(buffer[4:]))
+				locInfo := NewLocationInfo(string(buffer[4:n]))
+				log.Infof("LCR: Latitude: %f, Longitude: %f, Range: %f\n", locInfo.Latitude, locInfo.Longitude, locInfo.Range)
 				ctrl.SendToRadioMsgChannel([]byte("LCR," + string(buffer[4:])))
 			case "URC":
 				log.Infoln("URC:", string(buffer[4:]))

--- a/server/structs.go
+++ b/server/structs.go
@@ -463,3 +463,21 @@ func NewDateTimeInfo(raw string) *DateTimeInfo {
 		RTCOK:           rtc,
 	}
 }
+
+type LocationInfo struct {
+	Latitude  float64
+	Longitude float64
+	Range     float64
+}
+
+func NewLocationInfo(raw string) *LocationInfo {
+	split := strings.Split(raw, ",")
+	lat, _ := strconv.ParseFloat(split[0], 10)
+	lon, _ := strconv.ParseFloat(split[1], 10)
+	ran, _ := strconv.ParseFloat(split[2], 10)
+	return &LocationInfo{
+		Latitude:  lat,
+		Longitude: lon,
+		Range:     ran,
+	}
+}

--- a/server/structs.go
+++ b/server/structs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type ScannerInfo struct {
@@ -444,4 +445,21 @@ func NewScannerStatus(raw string) *ScannerStatus {
 	resp.BacklightLevel, _ = strconv.Atoi(lines[43])
 
 	return &resp
+}
+
+type DateTimeInfo struct {
+	DaylightSavings bool
+	Time            *time.Time
+	RTCOK           bool
+}
+
+func NewDateTimeInfo(raw string) *DateTimeInfo {
+	parsedTime, _ := time.Parse("2006,1,2,15,4,5", raw[2:len(raw)-2])
+	dst, _ := strconv.ParseBool(raw[0:1])
+	rtc, _ := strconv.ParseBool(raw[len(raw)-1:])
+	return &DateTimeInfo{
+		DaylightSavings: dst,
+		Time:            &parsedTime,
+		RTCOK:           rtc,
+	}
 }

--- a/server/structs.go
+++ b/server/structs.go
@@ -481,3 +481,37 @@ func NewLocationInfo(raw string) *LocationInfo {
 		Range:     ran,
 	}
 }
+
+type UserRecordStatus struct {
+	Recording    bool
+	ErrorCode    *int
+	ErrorMessage *string
+}
+
+func NewUserRecordStatus(raw string) *UserRecordStatus {
+	split := strings.Split(raw, ",")
+	status, _ := strconv.ParseBool(split[0])
+	errCode := 0
+	errMsg := ""
+	ret := &UserRecordStatus{
+		Recording: status,
+	}
+	if len(split) > 1 {
+		errCode, _ = strconv.Atoi(split[1])
+		ret.ErrorCode = &errCode
+		switch errCode {
+		case 1:
+			errMsg = "FILE ACCESS ERROR"
+		case 2:
+			errMsg = "LOW BATTERY"
+		case 3:
+			errMsg = "SESSION OVER LIMIT"
+		case 4:
+			errMsg = "RTC LOST"
+		default:
+			errMsg = "Unknown"
+		}
+		ret.ErrorMessage = &errMsg
+	}
+	return ret
+}

--- a/server/structs.go
+++ b/server/structs.go
@@ -533,3 +533,39 @@ func NewUserRecordStatus(raw string) *UserRecordStatus {
 	}
 	return ret
 }
+
+type MenuMode struct {
+	ID    string
+	Index string
+}
+
+func (m *MenuMode) String() string {
+	bits := []string{m.ID}
+	if m.Index != "" && (m.ID == "SCAN_SYSTEM" || m.ID == "SCAN_DEPARTMENT" || m.ID == "SCAN_SITE" || m.ID == "SCAN_CHANNEL" || m.ID == "SRCH_RANGE" || m.ID == "FTO_CHANNEL") {
+		bits = append(bits, m.Index)
+	}
+	return strings.Join(bits, ",")
+}
+
+type MenuBack struct {
+	ReturnLevel int
+}
+
+func (m *MenuBack) String() string {
+	if m.ReturnLevel > 0 {
+		return fmt.Sprintf("0,%d", m.ReturnLevel)
+	}
+	return ""
+}
+
+type MenuSetValue struct {
+	ItemIndex int
+	Value     string
+}
+
+func (m *MenuSetValue) String() string {
+	if m.Value != "" {
+		return fmt.Sprintf("0,%s", strings.ReplaceAll(m.Value, ",", `\t`))
+	}
+	return fmt.Sprintf("0,%d", m.ItemIndex)
+}

--- a/server/structs.go
+++ b/server/structs.go
@@ -569,3 +569,12 @@ func (m *MenuSetValue) String() string {
 	}
 	return fmt.Sprintf("0,%d", m.ItemIndex)
 }
+
+type KeyPress struct {
+	Key  string
+	Mode string
+}
+
+func (k *KeyPress) String() string {
+	return fmt.Sprintf("%s,%s", k.Key, k.Mode)
+}

--- a/server/structs.go
+++ b/server/structs.go
@@ -1,6 +1,10 @@
 package main
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+	"strconv"
+	"strings"
+)
 
 type ScannerInfo struct {
 	XMLName     xml.Name `xml:"ScannerInfo"`
@@ -328,4 +332,116 @@ type MsiInfo struct {
 		No   string `xml:"No,attr"`
 		EOT  string `xml:"EOT,attr"`
 	} `xml:"Footer"`
+}
+
+type ScannerStatus struct {
+	// Best guesses based on
+	// https://github.com/suidroot/pyUniden/blob/e7705be191474ffada8af12bf1f09c0d4a65057d/pyuniden/main.py#L84-L122
+	// http://www.servicedocs.com/ARTIKELEN/7200250170003.pdf
+	// http://www.netfiles.ru/share/linked/f1/BCD396T_Protocol.pdf
+	Line1          string
+	Line2          string
+	Line3          string
+	Line4          string
+	Line5          string
+	Line6          string
+	Line7          string
+	Line8          string
+	Line9          string
+	Line10         string
+	Line11         string
+	Line12         string
+	Line13         string
+	Line14         string
+	Line15         string
+	Line16         string
+	Line17         string
+	Line18         string
+	Line19         string
+	Line20         string
+	Frequency      float64
+	Squelch        bool
+	Mute           bool
+	WeatherAlerts  bool
+	CCLed          bool
+	AlertLED       bool
+	BacklightLevel int
+	SignalLevel    int
+}
+
+func (s *ScannerStatus) Command() string {
+	return "STS"
+}
+
+func NewScannerStatus(raw string) *ScannerStatus {
+	lines := strings.Split(raw, ",")
+
+	resp := ScannerStatus{}
+
+	if len(lines) >= 2 {
+		resp.Line1 = lines[1]
+	}
+	if len(lines) >= 4 {
+		resp.Line2 = lines[3]
+	}
+	if len(lines) >= 6 {
+		resp.Line3 = lines[5]
+	}
+	if len(lines) >= 8 {
+		resp.Line4 = lines[7]
+	}
+	if len(lines) >= 10 {
+		resp.Line5 = lines[9]
+	}
+	if len(lines) >= 12 {
+		resp.Line6 = lines[11]
+	}
+	if len(lines) >= 14 {
+		resp.Line7 = lines[13]
+	}
+	if len(lines) >= 16 {
+		resp.Line8 = lines[15]
+	}
+	if len(lines) >= 18 {
+		resp.Line9 = lines[17]
+	}
+	if len(lines) >= 20 {
+		resp.Line10 = lines[19]
+	}
+	if len(lines) >= 22 {
+		resp.Line11 = lines[21]
+	}
+	if len(lines) >= 24 {
+		resp.Line12 = lines[23]
+	}
+	if len(lines) >= 26 {
+		resp.Line13 = lines[25]
+	}
+	if len(lines) >= 28 {
+		resp.Line14 = lines[27]
+	}
+	if len(lines) >= 30 {
+		resp.Line15 = lines[29]
+	}
+	if len(lines) >= 32 {
+		resp.Line16 = lines[31]
+	}
+	if len(lines) >= 34 {
+		resp.Line17 = lines[33]
+	}
+	if len(lines) >= 36 {
+		resp.Line18 = lines[35]
+	}
+	if len(lines) >= 38 {
+		resp.Line19 = lines[37]
+	}
+	if len(lines) >= 40 {
+		resp.Line20 = lines[39]
+	}
+
+	resp.Squelch = (lines[36] == "0")
+	resp.SignalLevel, _ = strconv.Atoi(lines[41])
+	resp.BacklightLevel, _ = strconv.Atoi(lines[43])
+
+	return &resp
 }

--- a/server/structs.go
+++ b/server/structs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/xml"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -447,14 +448,20 @@ func NewScannerStatus(raw string) *ScannerStatus {
 	return &resp
 }
 
+const DateTimeFormat = "2006,1,2,15,4,5"
+
 type DateTimeInfo struct {
 	DaylightSavings bool
 	Time            *time.Time
 	RTCOK           bool
 }
 
+func (d *DateTimeInfo) String() string {
+	return fmt.Sprintf("%d,%s,%d", d.DaylightSavings, d.Time.Format(DateTimeFormat), d.RTCOK)
+}
+
 func NewDateTimeInfo(raw string) *DateTimeInfo {
-	parsedTime, _ := time.Parse("2006,1,2,15,4,5", raw[2:len(raw)-2])
+	parsedTime, _ := time.Parse(DateTimeFormat, raw[2:len(raw)-2])
 	dst, _ := strconv.ParseBool(raw[0:1])
 	rtc, _ := strconv.ParseBool(raw[len(raw)-1:])
 	return &DateTimeInfo{
@@ -468,6 +475,10 @@ type LocationInfo struct {
 	Latitude  float64
 	Longitude float64
 	Range     float64
+}
+
+func (l *LocationInfo) String() string {
+	return fmt.Sprintf("%f,%f,%f", l.Latitude, l.Longitude, l.Range)
 }
 
 func NewLocationInfo(raw string) *LocationInfo {
@@ -486,6 +497,13 @@ type UserRecordStatus struct {
 	Recording    bool
 	ErrorCode    *int
 	ErrorMessage *string
+}
+
+func (u *UserRecordStatus) String() string {
+	if u.Recording {
+		return "1"
+	}
+	return "0"
 }
 
 func NewUserRecordStatus(raw string) *UserRecordStatus {

--- a/server/utils.go
+++ b/server/utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/xml"
 	"strings"
 	"unicode"
@@ -173,5 +174,27 @@ func IsValidXMLMessage(msgType string, buffer []byte) bool {
 
 	clean := buffer[11:]
 
-	return xml.Unmarshal(clean, &msg) == nil
+	if xmlErr := xml.Unmarshal(clean, &msg); xmlErr != nil {
+		log.Debugln("Error when checking validity of XML message", xmlErr)
+		return false
+	}
+
+	return true
+}
+
+// https://stackoverflow.com/a/52395088/486182
+func ScanLinesWithCR(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, '\r'); i >= 0 {
+		// We have a full newline-terminated line.
+		return i + 1, data[0:i], nil
+	}
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+	}
+	// Request more data.
+	return 0, nil, nil
 }


### PR DESCRIPTION
Adds decode and encode support for the following commands:

- `STS`
- `DTM`
- `LCR`
- `UCR`
- `MNU`
- `MSB`
- `MSV`
- `KEY`


Also improves SDS100 parsing by using `bufio`'s Scanner.